### PR TITLE
Add missing AES-192-CFB128

### DIFF
--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -40,22 +40,6 @@
 #include <sys/system_properties.h>
 #endif
 
-#if !defined(OPENSSL_ANDROID)
-#define OPENSSL_HAS_GETAUXVAL
-#endif
-// glibc prior to 2.16 does not have getauxval and sys/auxv.h. Android has some
-// host builds (i.e. not building for Android itself, so |OPENSSL_ANDROID| is
-// unset) which are still using a 2.15 sysroot.
-//
-// TODO(davidben): Remove this once Android updates their sysroot.
-#if defined(__GLIBC_PREREQ)
-#if !__GLIBC_PREREQ(2, 16)
-#undef OPENSSL_HAS_GETAUXVAL
-#endif
-#endif
-#if defined(OPENSSL_HAS_GETAUXVAL)
-#include <sys/auxv.h>
-#endif
 #endif  // OPENSSL_LINUX
 
 #if defined(OPENSSL_MACOS)

--- a/decrepit/cfb/cfb.c
+++ b/decrepit/cfb/cfb.c
@@ -57,6 +57,13 @@ static const EVP_CIPHER aes_128_cfb128 = {
     NULL /* cleanup */,  NULL /* ctrl */,
 };
 
+static const EVP_CIPHER aes_192_cfb128 = {
+    NID_aes_192_cfb128,  1 /* block_size */,  24 /* key_size */,
+    16 /* iv_len */,     sizeof(EVP_CFB_CTX), EVP_CIPH_CFB_MODE,
+    NULL /* app_data */, aes_cfb_init_key,    aes_cfb128_cipher,
+    NULL /* cleanup */,  NULL /* ctrl */,
+};
+
 static const EVP_CIPHER aes_256_cfb128 = {
     NID_aes_256_cfb128,  1 /* block_size */,  32 /* key_size */,
     16 /* iv_len */,     sizeof(EVP_CFB_CTX), EVP_CIPH_CFB_MODE,
@@ -65,4 +72,5 @@ static const EVP_CIPHER aes_256_cfb128 = {
 };
 
 const EVP_CIPHER *EVP_aes_128_cfb128(void) { return &aes_128_cfb128; }
+const EVP_CIPHER *EVP_aes_192_cfb128(void) { return &aes_192_cfb128; }
 const EVP_CIPHER *EVP_aes_256_cfb128(void) { return &aes_256_cfb128; }

--- a/include/openssl/cipher.h
+++ b/include/openssl/cipher.h
@@ -431,6 +431,9 @@ OPENSSL_EXPORT const EVP_CIPHER *EVP_des_ede3_ecb(void);
 // EVP_aes_128_cfb128 is only available in decrepit.
 OPENSSL_EXPORT const EVP_CIPHER *EVP_aes_128_cfb128(void);
 
+// EVP_aes_192_cfb128 is only available in decrepit.
+OPENSSL_EXPORT const EVP_CIPHER *EVP_aes_192_cfb128(void);
+
 // EVP_aes_256_cfb128 is only available in decrepit.
 OPENSSL_EXPORT const EVP_CIPHER *EVP_aes_256_cfb128(void);
 


### PR DESCRIPTION
Add missing AES-192-CFB128 mode.

This cipher mode is obscure and rarely needed.
Unfortunately, it was already added to ClickHouse encrypt/decrypt functions with a bunch of other modes.