### PR TITLE
update cmake_minimum_required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,9 +333,9 @@ if(CFI)
 
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=cfi -fno-sanitize-trap=cfi -flto=thin")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=cfi -fno-sanitize-trap=cfi -flto=thin")
-  # We use Chromium's copy of clang, which requires -fuse-ld=lld if building
+  # We use Chromium's copy of clang, which requires ---ld-path=lld if building
   # with -flto. That, in turn, can't handle -ggdb.
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ---ld-path=lld")
   string(REPLACE "-ggdb" "-g" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
   string(REPLACE "-ggdb" "-g" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
   # -flto causes object files to contain LLVM bitcode. Mixing those with

--- a/crypto/fipsmodule/rand/urandom.c
+++ b/crypto/fipsmodule/rand/urandom.c
@@ -151,7 +151,7 @@ static void init_once(void) {
   }
 #endif  // USE_NR_getrandom
 
-#if defined(OPENSSL_MACOS)
+#if defined(OPENSSL_MACOS) && __has_builtin(__builtin_available)
   // getentropy is available in macOS 10.12 and up. iOS 10 and up may also
   // support it, but the header is missing. See https://crbug.com/boringssl/287.
   if (__builtin_available(macos 10.12, *)) {
@@ -299,7 +299,7 @@ static int fill_with_entropy(uint8_t *out, size_t len, int block, int seed) {
     if (*urandom_fd_bss_get() == kHaveGetrandom) {
 #if defined(USE_NR_getrandom)
       r = boringssl_getrandom(out, len, getrandom_flags);
-#elif defined(OPENSSL_MACOS)
+#elif defined(OPENSSL_MACOS) && __has_builtin(__builtin_available)
       if (__builtin_available(macos 10.12, *)) {
         // |getentropy| can only request 256 bytes at a time.
         size_t todo = len <= 256 ? len : 256;


### PR DESCRIPTION
CMake versions prior VERSION 2.8.12 are not supported in CMake 3.19+
